### PR TITLE
Add rule for E999

### DIFF
--- a/_rules/E999.md
+++ b/_rules/E999.md
@@ -1,0 +1,23 @@
+---
+code: E999
+message: "SyntaxError"
+title: "SyntaxError (E999)"
+links:
+  - https://github.com/PyCQA/flake8/blob/master/docs/source/user/error-codes.rst#L89
+---
+
+E999 is reported in the case of failure to compile a file into an Abstract Syntax Tree for the plugins that require it.
+
+### Example
+
+Running the following statement would report an E999 error.
+
+```python
+print("Hello world)
+```
+
+### Output
+
+```
+E999 SyntaxError: EOL while scanning string literal
+```


### PR DESCRIPTION
### Issue
#8 Missing E999

### Solution
Add a rule for E999. This one is broad in scope and doesn't fit the `anti-pattern`, `best practice` format for other rules, so I just added an example.