### PR TITLE
Improve readability for W292 example by fixing the markdown

### DIFF
--- a/_rules/W292.md
+++ b/_rules/W292.md
@@ -23,5 +23,5 @@ Imagine the example below is an entire file.
 import os
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
+# This is new line ends the file.
 ```

--- a/_rules/W292.md
+++ b/_rules/W292.md
@@ -23,5 +23,5 @@ Imagine the example below is an entire file.
 import os
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-# This is new line ends the file.
+# This is a new line that ends the file.
 ```

--- a/_rules/W292.md
+++ b/_rules/W292.md
@@ -13,8 +13,8 @@ Imagine the example below is an entire file.
 ```python
 import os
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))```
-
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+```
 ### Best practice
 
 Imagine the example below is an entire file.
@@ -23,4 +23,5 @@ Imagine the example below is an entire file.
 import os
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
 ```


### PR DESCRIPTION
### Goals ⚽
I came across the webpage for [W292](https://www.flake8rules.com/rules/W292.html) which seems to be broken (or confusing) by the three back-ticks of markdown.  This seems to be caused by commit [2f04993](https://github.com/grantmcconnaughey/Flake8Rules/commit/2f04993177f355fc953ee46879fe533cad93becb). My goal is to improve the clarity for this page. See below for the currently live version:

<img width="1023" alt="Screen Shot 2020-05-22 at 3 48 10 PM" src="https://user-images.githubusercontent.com/5597604/82714545-0a230d80-9c44-11ea-8ffd-e3c982c5b971.png">

### Implementation Details 🚧
I fixed the markdown and added a comment so that it is clear to the developer who compares Anti-pattern and Best practice.

### Testing Details 🔍
Here's the preview -

<img width="619" alt="Screen Shot 2020-05-22 at 3 53 35 PM" src="https://user-images.githubusercontent.com/5597604/82714639-6e45d180-9c44-11ea-8230-04c3e8aeeef7.png">
