### PR TITLE
Removed `if` from the title and capitalised `None`

### DIFF
--- a/_rules/E711.md
+++ b/_rules/E711.md
@@ -1,7 +1,7 @@
 ---
 code: E711
-message: "Comparison to none should be 'if cond is none:'"
-title: "Comparison to none should be 'if cond is none:' (E711)"
+message: "Comparison to None should be 'cond is None:'"
+title: "Comparison to None should be 'cond is None:' (E711)"
 links:
   - https://www.python.org/dev/peps/pep-0008/#programming-recommendations
 ---


### PR DESCRIPTION
The title wording is a bit confusing as can be seen from https://stackoverflow.com/questions/69908588/ as this rule doesn't only apply to `if` statements. Made it more generic and also fixed the capitalisation of `None`.