### PR TITLE
Remove HTML entity from E501 title

### DIFF
--- a/_rules/E501.md
+++ b/_rules/E501.md
@@ -1,7 +1,7 @@
 ---
 code: E501
-message: "Line too long (82 &gt; 79 characters)"
-title: "Line too long (82 &gt; 79 characters) (E501)"
+message: "Line too long (82 > 79 characters)"
+title: "Line too long (82 > 79 characters) (E501)"
 links:
   - https://www.python.org/dev/peps/pep-0008/#maximum-line-length
 ---


### PR DESCRIPTION
[E501](https://www.flake8rules.com/rules/E501.html) title displays an HTML entity:

```
Line too long (82 &gt; 79 characters) (E501)
```


Is there any reason for that symbol to be an HTML entity in the source Markdown file?

Another possible option is to remove the `escape` filter [here](https://github.com/grantmcconnaughey/Flake8Rules/blob/914c9bac3018a4c9fa8359bdfd24c686d5be2bef/_layouts/rule.html#L7), but that's likely to cause side-effects on other titles.