### PR TITLE
add missing `:` in E711 example code

### DIFF
--- a/_rules/E711.md
+++ b/_rules/E711.md
@@ -20,9 +20,8 @@ if var == None:
 ### Best practice
 
 ```python
-if var is not True
+if var is not True:
     print("var is not True")
-if var is None
+if var is None:
     print("var is None")
-   
 ```


### PR DESCRIPTION
add missing `:` after the condition